### PR TITLE
Formatting and style fixes for public waitlist page.

### DIFF
--- a/pageContent/fcFleetList.js
+++ b/pageContent/fcFleetList.js
@@ -28,7 +28,7 @@ var fleets = "";
       <td><a href="#">${payloadContent.fleets[i].backseat.name || "None"}</a>
       <td>${payloadContent.fleets[i].type}</td>
       <td>${payloadContent.fleets[i].status}</td>
-      <td>${payloadContent.fleets[i].location.name || "Unknown"}</td>
+      <td><a href="#">${payloadContent.fleets[i].location.name || "Unknown"}</a></td>
       <td>${payloadContent.fleets[i].members.length}</td>
       <td><a href="/commander/${payloadContent.fleets[i].id}"><button class="btn btn-sm btn-info"><i class="fa fa-binoculars"></i></button></a></td>
     </tr>

--- a/pageContent/publicWaitlist.js
+++ b/pageContent/publicWaitlist.js
@@ -7,8 +7,9 @@ module.exports = function(payloadContent) {
 var fleets = "";
   for (var i = 0; i < payloadContent.fleets.length; i++) {
     fleets += `
+              <div class="col-md-6 col-sm-12"> 
+                <div class="statistic-block block">
                   <div class="title"  style="padding-top:25px">
-                    <div class="icon"></div>
                     <strong>Fleet Info</strong>
                   </div>
                   <table class="table table-striped table-hover table-sm noselect">
@@ -43,8 +44,8 @@ var fleets = "";
                       </tr>
                     </tbody>
                   </table>
-                </div>
-              </div>
+                </div> 
+              </div>          
     `
   }
 
@@ -70,10 +71,9 @@ var fleets = "";
             <!-- Waitlist Panel -->
             <div class="row">
               <!-- Waitlist Panel -->
-              <div class="col-md-4 col-sm-6">
+              <div class="col-md-4 col-sm-12">
                 <div class="statistic-block block">
                   <div class="title">
-                    <div class="icon"></div>
                     <strong>Join the Waitlist</strong>
                   </div>
                     <!-- Select Character -->
@@ -160,13 +160,10 @@ var fleets = "";
                       </div>
                     </div>
                 </div>
-              </div>
-              <!-- End Waitlist Panel -->
-              <!-- Fleet Info -->
-              <div class="col-md-4 col-sm-6">
+                <!-- End Waitlist Panel -->
+                <!-- Waitlist Queue Panel -->
                 <div class="statistic-block block">
-                  <div class="title">
-                    <div class="icon"></div>
+                  <div class="title">                    
                     <strong>Queue Info</strong>
                   </div>
                   <!-- Your Position Table -->
@@ -176,17 +173,28 @@ var fleets = "";
                         <td class="tw60per">Your Position:</td>
                         <td>${position.position || "##"} out of ${position.length || "##"}</td>
                       </tr>
-                      <!--<tr>
+                      <tr>
                         <td>Wait Time:</td>
                         <td>00H 11M</td>
-                      </tr>-->
+                      </tr>
                     </tbody>
                   </table>
+                </div>
+              </div>
+              <!-- End Waitlist Queue Panel -->
+              
+              <!-- Fleet Info -->
+              <div class="col-md-8 col-sm-12">
+                <div class="row">
                   <!-- Fleet Info Table -->		  
                   ${fleets}
-              <!-- Fleet Info -->
+                </div>
+              </div>
+              
+              <!-- End Fleet Info -->
+              
             </div>
-          </div>
+          </div> 
         </section>
         `;
 }

--- a/pageContent/publicWaitlist.js
+++ b/pageContent/publicWaitlist.js
@@ -9,7 +9,7 @@ var fleets = "";
     fleets += `
               <div class="col-md-6 col-sm-12"> 
                 <div class="statistic-block block">
-                  <div class="title"  style="padding-top:25px">
+                  <div class="title">
                     <strong>Fleet Info</strong>
                   </div>
                   <table class="table table-striped table-hover table-sm noselect">
@@ -64,14 +64,37 @@ var fleets = "";
           <div role="alert" class="alert alert-dark global-banner">
             <strong>PLEASE NOTE:</strong> This waitlist is in heavy, heavy alpha. Most things do not work, wording will be incorrect and things will break. Click <a href="https://github.com/Makeshift/eve-goons-waitlist/issues/new">HERE</a> to submit a bug report.
           </div>
+          <!-- No Fleet -->
+          <div role="alert" class="alert alert-primary global-banner-inactive">
+            <strong>Waitlist Inactive:</strong> There is either no fleets, or the waitlist is not being used. Check our in-game channel for more information!
+          </div>
         </section>
         <!-- Main Content -->
         <section class="no-padding-top padding-bottom">
           <div class="container-fluid">
-            <!-- Waitlist Panel -->
             <div class="row">
-              <!-- Waitlist Panel -->
               <div class="col-md-4 col-sm-12">
+                <!-- Waitlist Queue Panel -->
+                <div class="statistic-block block">
+                  <div class="title">                    
+                    <strong>Queue Info</strong>
+                  </div>
+                  <!-- Your Position Table -->
+                  <table class="table table-striped table-hover table-sm noselect">
+                    <tbody>
+                      <tr>
+                        <td class="tw60per">Your Position:</td>
+                        <td>${position.position || "##"} out of ${position.length || "##"}</td>
+                      </tr>
+                      <tr>
+                        <td>Wait Time:</td>
+                        <td>00H 11M</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!-- End Waitlist Queue Panel -->
+                <!-- Waitlist Panel -->
                 <div class="statistic-block block">
                   <div class="title">
                     <strong>Join the Waitlist</strong>
@@ -161,27 +184,8 @@ var fleets = "";
                     </div>
                 </div>
                 <!-- End Waitlist Panel -->
-                <!-- Waitlist Queue Panel -->
-                <div class="statistic-block block">
-                  <div class="title">                    
-                    <strong>Queue Info</strong>
-                  </div>
-                  <!-- Your Position Table -->
-                  <table class="table table-striped table-hover table-sm noselect">
-                    <tbody>
-                      <tr>
-                        <td class="tw60per">Your Position:</td>
-                        <td>${position.position || "##"} out of ${position.length || "##"}</td>
-                      </tr>
-                      <tr>
-                        <td>Wait Time:</td>
-                        <td>00H 11M</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
               </div>
-              <!-- End Waitlist Queue Panel -->
+              
               
               <!-- Fleet Info -->
               <div class="col-md-8 col-sm-12">

--- a/public/includes/css/custom.css
+++ b/public/includes/css/custom.css
@@ -8,6 +8,13 @@ body{
 	font-weight: normal;
 }
 
+/* Navbar Icons */
+nav#sidebar.shrinked > ul > li > a > .svg-inline--fa, nav#sidebar.shrinked > ul > li > a > span.fa-layers{
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 /* White text on info buttons */
 .btn-info{
 	color: white;

--- a/public/includes/css/custom.css
+++ b/public/includes/css/custom.css
@@ -3,6 +3,11 @@ body{
 	overflow-x: hidden!important;
 }
 
+/* Card Titles */
+.title strong{
+	font-weight: normal;
+}
+
 /* White text on info buttons */
 .btn-info{
 	color: white;
@@ -40,7 +45,6 @@ body{
 
 /* global-banner */
 .global-banner{
-	width: 94%;
 	margin-left: 1.5%;
 	margin-right: 1.5%;
 	margin-top: -20px;

--- a/public/includes/css/custom.css
+++ b/public/includes/css/custom.css
@@ -58,6 +58,17 @@ nav#sidebar.shrinked > ul > li > a > .svg-inline--fa, nav#sidebar.shrinked > ul 
 	border-radius: 0px;
 }
 
+/* No Fleet-banner */
+.global-banner-inactive{
+	margin-left: 1.5%;
+	margin-right: 1.5%;
+	margin-top: -20px;
+	border-radius: 0px;
+	color: white;
+	background-color: #dc3545;
+	border-color: white;
+}
+
 
 /* Fit selection buttons */
 .fit-selected, .fit:hover, .fit:focus{


### PR DESCRIPTION
- Fixed the global-banner so that it displays at full width rather than 94%.
- Moved the Queue Info so that it's on the left and not part of the fleet cards.
- Waitlist will now display multiple fleets correctly on the right side of the screen.
- The Join the waitlist panel and fleet queue panel are now full width on small devices.
- Added a fix for navbar side icons.