### PR TITLE
Ui Fixes and Improvements.

### DIFF
--- a/pageContent/fcFleetList.js
+++ b/pageContent/fcFleetList.js
@@ -27,7 +27,7 @@ var fleets = "";
       <td><a href="#">${payloadContent.fleets[i].backseat.name || "None"}</a>
       <td>${payloadContent.fleets[i].type}</td>
       <td>${payloadContent.fleets[i].status}</td>
-      <td><a href="#">${payloadContent.fleets[i].location.name || "Unknown"}</a></td>
+      <td><a href="#">${payloadContent.fleets[i].location || "Unknown"}</a></td>
       <td>${payloadContent.fleets[i].members.length}</td>
       <td><a href="/commander/${payloadContent.fleets[i].id}"><button class="btn btn-sm btn-info"><i class="fa fa-binoculars"></i></button></a></td>
     </tr>

--- a/pageContent/publicWaitlist.js
+++ b/pageContent/publicWaitlist.js
@@ -48,7 +48,7 @@ var fleets = "";
                       </tr>                      
                       <tr>
                         <td>Fleet Location:</td>
-                        <td><a href="#">${payloadContent.fleets[i].location.name}</a></td>
+                        <td><a href="#">${payloadContent.fleets[i].location}</a></td>
                       </tr>
                       <tr>
                         <td>Fleet Comms:</td>
@@ -60,7 +60,7 @@ var fleets = "";
               </div>          
     `
   }
-
+  
 waitlist.getUserPosition(payloadContent.user.characterID, function(position, found, name) {
   waitlist.getCharsOnWaitlist(payloadContent.user.characterID, function(charList) {
     //If they have a char in the waitlist AND they have no related chars, hide the "Join Waitlist" button

--- a/pageContent/publicWaitlist.js
+++ b/pageContent/publicWaitlist.js
@@ -147,7 +147,7 @@ waitlist.getUserPosition(payloadContent.user.characterID, function(position, fou
                         <label for="lan"><div class="d-inline" data-toggle="tooltip" title="Select English if you can understand FC instructions. If your English skills are poor, please select your primary language."><i class="fas fa-info-circle"></i></div>  Language:</label>
                         <select name="language" class="form-control" id="lan">
                           <option value="">Choose</option>
-                          <option value="English">English</option>
+                          <option value="English" selected>English</option>
                           <option value="Chinese">Chinese</option>
                           <option value="German">German</option>
                           <option value="French">French</option>

--- a/pageContent/publicWaitlist.js
+++ b/pageContent/publicWaitlist.js
@@ -6,7 +6,7 @@ module.exports = function(payloadContent, cb) {
 
 var inactive = "";
 if (payloadContent.fleets.length === 0) {
-  inactive = `<div role="alert" class="alert alert-primary global-banner-inactive">
+  inactive = `<div role="alert" class="alert alert-primary global-banner-inactive noselect">
             <strong>Waitlist Inactive:</strong> There is either no fleets, or the waitlist is not being used. Check our in-game channel for more information!
           </div>`
 }
@@ -87,7 +87,7 @@ waitlist.getUserPosition(payloadContent.user.characterID, function(position, fou
         cb(`
         <!-- Page Content -->
         <div class="page-content">
-          <div class="page-header">
+          <div class="page-header noselect">
             <div class="container-fluid">
               <h2 class="h5 no-margin-bottom"><strong class="text-primary">THE</strong><strong>WAITLIST</strong></h2>
             </div>
@@ -100,12 +100,12 @@ waitlist.getUserPosition(payloadContent.user.characterID, function(position, fou
             </div>
           </section>
           <!-- Main Content -->
-          <section class="no-padding-top padding-bottom">
+          <section class="no-padding-top padding-bottom noselect">
             <div class="container-fluid">
               <div class="row">
                 <div class="col-lg-4 col-md-6 col-sm-12">
                   <!-- Waitlist Queue Panel -->
-                  <div class="statistic-block block">
+                  <div class="statistic-block block noselect">
                     <div class="title">                    
                       <strong>Queue Info</strong>
                     </div>

--- a/public/includes/css/custom.css
+++ b/public/includes/css/custom.css
@@ -166,7 +166,7 @@ nav#sidebar.shrinked > ul > li > a > .svg-inline--fa, nav#sidebar.shrinked > ul 
 }
 
 /* No Select */
-.noselect, .global-banner, .title, .number, form, img, nav, footer, table{
+.noselect, .global-banner, img, footer, nav{
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
      -khtml-user-select: none; /* Konqueror HTML */

--- a/users.js
+++ b/users.js
@@ -92,7 +92,7 @@ module.exports = function (setup) {
 			name: characterDetails.CharacterName,
 			scopes: characterDetails.Scopes,
 			refreshToken: refreshToken,
-			avatar: "http://image.eveonline.com/Character/" + characterDetails.CharacterID + "_128.jpg",
+			avatar: "https://image.eveonline.com/Character/" + characterDetails.CharacterID + "_128.jpg",
 			role: "Member",
 			roleNumeric: 0,
 			registrationDate: new Date(),


### PR DESCRIPTION
Various fixes and improvements. 

- [Issue #34](https://github.com/Makeshift/eve-goons-waitlist/issues/34) - English is now the default option for users selecting a language. 

- [Issue #39](https://github.com/Makeshift/eve-goons-waitlist/issues/39) - New users will have an image url using https. Old users still have http. Any page loading an avatar over http will not show up as secure for users.

- [Issue #38](https://github.com/Makeshift/eve-goons-waitlist/issues/38) - The no select styling has been removed from most areas of the site.

- Fleet location now shows up on the public waitlist page and fleet listing page.