### PR TITLE
Waitlist Banners + No ESI Waitlist +failed invite feedback + user/users.js

### DIFF
--- a/controllers/apiController.js
+++ b/controllers/apiController.js
@@ -5,6 +5,7 @@ const fleets = require('../fleets.js')(setup);
 const user = require('../user.js')(setup);
 const users = require('../users.js')(setup);
 const refresh = require('passport-oauth2-refresh');
+const banner = require('../waitlistBanner.js')(setup);
 const waitlist = require('../globalWaitlist.js')(setup);
 const log = require('../logger.js')(module);
 const wlog = require('../wlog.js');
@@ -60,6 +61,28 @@ exports.fleetAtAGlance = function(req, res) {
             res.status(400).send("No fleet found");
         }
     });     
+}
+
+//Store a new banner
+exports.addBanner = function(req, res){
+    if(req.isAuthenticated() && req.user.roleNumeric > 0){
+        banner.createNew(req.user, req.body.text, req.body.type, function(status){
+            res.status(status).send();
+        })
+    } else {
+        res.status(400).send("Not authorised");
+    }
+}
+
+//Hide last banner
+exports.removeBanner = function(req, res){
+    if(req.isAuthenticated() && req.user.roleNumeric > 0){
+        banner.hideLast(function(status){
+            res.status(status).send();
+        })
+    } else {
+        res.status(400).send("Not authorised");
+    }
 }
 
 //Count the total number of each ship and make the table.

--- a/controllers/apiController.js
+++ b/controllers/apiController.js
@@ -2,6 +2,7 @@ const path = require('path');
 const setup = require('../setup.js');
 const cache = require('../cache.js')(setup);
 const fleets = require('../fleets.js')(setup);
+const user = require('../user.js')(setup);
 const users = require('../users.js')(setup);
 const refresh = require('passport-oauth2-refresh');
 const waitlist = require('../globalWaitlist.js')(setup);
@@ -11,7 +12,7 @@ const api = require('./apiController');
 
 exports.waypoint = function(req, res) {
     if (req.isAuthenticated() && typeof req.params.systemID !== "undefined") {
-        users.setDestination(req.user, req.params.systemID, function(response) {
+        user.setDestination(req.user, req.params.systemID, function(response) {
             res.send(response);
         });
     } else {
@@ -21,7 +22,7 @@ exports.waypoint = function(req, res) {
 
 exports.showInfo = function(req, res) {
     if (req.isAuthenticated() && typeof req.params.targetID !== "undefined") {
-        users.showInfo(req.user, req.params.targetID, function(response) {
+        user.showInfo(req.user, req.params.targetID, function(response) {
             res.send(response);
         });
     } else {
@@ -31,7 +32,7 @@ exports.showInfo = function(req, res) {
 
 exports.openMarket = function(req, res) {
     if(req.isAuthenticated() && typeof req.params.targetID !== "undefined") {
-        users.openMarketWindow(req.user, req.params.targetID, function(response) {
+        user.openMarketWindow(req.user, req.params.targetID, function(response) {
             res.send(response);
         });
     } else {

--- a/controllers/commanderController.js
+++ b/controllers/commanderController.js
@@ -1,8 +1,9 @@
-var path = require('path');
-var setup = require('../setup.js');
-var fleets = require('../fleets.js')(setup);
-var users = require('../users.js')(setup);
-var refresh = require('passport-oauth2-refresh');
+const path = require('path');
+const setup = require('../setup.js');
+const fleets = require('../fleets.js')(setup);
+const user = require('../user.js')(setup);
+const users = require('../users.js')(setup);
+const refresh = require('passport-oauth2-refresh');
 const log = require('../logger.js')(module);
 
 
@@ -29,7 +30,7 @@ exports.index = function(req, res) {
 //Registers a fleet
 exports.registerFleet = function(req, res) {
     if (req.isAuthenticated() && req.user.roleNumeric > 0) {
-        users.getLocation(req.user, function (location) {
+        user.getLocation(req.user, function (location) {
             var fleetid = 0;
             try {
                 fleetid = req.body.url.split("fleets/")[1].split("/")[0];

--- a/controllers/pagesController.js
+++ b/controllers/pagesController.js
@@ -1,29 +1,32 @@
-var path = require('path');
-var setup = require('../setup.js');
-var fleets = require('../fleets.js')(setup);
-var esi = require('eve-swagger');
-var waitlist = require('../globalWaitlist.js')(setup);
+const path = require('path');
+const setup = require('../setup.js');
+const fleets = require('../fleets.js')(setup);
+const esi = require('eve-swagger');
+const banner = require('../waitlistBanner.js')(setup);
+const waitlist = require('../globalWaitlist.js')(setup);
 const log = require('../logger.js')(module);
 const wlog = require('../wlog.js');
 
 //Render Index/login Page
 exports.index = function(req, res) {
     if (req.isAuthenticated()) {
-        //Grab all fleets			
-        fleets.getFCPageList(function (fleets) {           
-            var fleetCount = 0;
-            for (var i = 0; i < fleets.length; i++) {
-                if (fleets[i].status !== "Not Listed") fleetCount++;
-            }
-            
-            waitlist.getUserPosition(req.user.characterID, function(position, found, name) {
-                waitlist.getCharsOnWaitlist(req.user.characterID, function(charList) {
-                    var userProfile = req.user;
-                    var sideBarSelected = 1;
-                    res.render('waitlist.njk', {userProfile, sideBarSelected, fleets, fleetCount, charList, position});
+        banner.getLast(function (banner){
+            //Grab all fleets			
+            fleets.getFCPageList(function (fleets) {           
+                var fleetCount = 0;
+                for (var i = 0; i < fleets.length; i++) {
+                    if (fleets[i].status !== "Not Listed") fleetCount++;
+                }
+                
+                waitlist.getUserPosition(req.user.characterID, function(position, found, name) {
+                    waitlist.getCharsOnWaitlist(req.user.characterID, function(charList) {
+                        var userProfile = req.user;
+                        var sideBarSelected = 1;
+                        res.render('waitlist.njk', {userProfile, sideBarSelected, banner, fleets, fleetCount, charList, position});
+                    })
                 })
             })
-        });
+        })
     } else {
         res.render('login.html');
     }

--- a/globalWaitlist.js
+++ b/globalWaitlist.js
@@ -3,6 +3,7 @@ const path = require('path');
 const db = require('./dbHandler.js').db.collection('waitlist');
 const ObjectId = require('mongodb').ObjectID;
 const setup = require('./setup.js');
+const user = require('./user.js')(setup);
 const users = require('./users.js')(setup);
 const log = require('./logger.js')(module);
 
@@ -127,7 +128,7 @@ module.exports = function (setup) {
 				db.find().forEach(function (doc) {
 					//Is user online?
 					//Update Location
-					users.getLocation(doc.user, function(location) {
+					user.getLocation(doc.user, function(location) {
 						doc.user.location = location;
 						db.updateOne({ '_id': doc._id }, { $set: { "user": doc.user } }, function (err, result) {
 							if (err) log.error("waitlist.getLocation: Error for db.updateOne", { err });

--- a/globalWaitlist.js
+++ b/globalWaitlist.js
@@ -77,7 +77,6 @@ module.exports = function (setup) {
 	}
 	//Temporary - This will delete the first alt it finds on the waitlist, it can be pressed multiple times to remove all of them
 	module.selfRemove = function(characterID, cb) {
-		log.debug(`User removed themselves from waitlist: ${characterID}`);
 		db.deleteOne({ 'user.characterID': characterID }, function(err, result) {
 			if (err) log.error("selfRemove: Error for db.deleteOne", { err, 'characterID': characterID });
 			if (cb) cb();

--- a/public/includes/css/custom.css
+++ b/public/includes/css/custom.css
@@ -101,7 +101,23 @@ nav#sidebar.shrinked > ul > li > a > .svg-inline--fa, nav#sidebar.shrinked > ul 
 	background-color: #dc3545;
 	border-color: white;
 }
+/* Waitlist Info Banner */
+.banner-info{
+	background-color:#06577d;
+	color: white;
+	margin-left: 1.5%;
+	margin-right: 1.5%;
+	border-radius: 0px;
+}
 
+/* Waitlist Warning Banner */
+.banner-warning{
+	background-color:#dc3545;
+	color: white;
+	margin-left: 1.5%;
+	margin-right: 1.5%;
+	border-radius: 0px;
+}		
 
 /* Fit selection buttons */
 .fit-selected, .fit:hover, .fit:focus{

--- a/routes.js
+++ b/routes.js
@@ -54,4 +54,7 @@ const fc_tools_controller = require('./controllers/fcToolsController.js')
 	router.post('/internal-api/fleetcomp/:fleetid/:filter', api_controller.fleetAtAGlance);
 	router.post('/internal-api/alarm-user/:targetid/:fleetid', api_controller.alarmUser);
 	router.post('/internal-api/waitlist/remove-all', fleet_management_controller.clearWaitlist);
+	router.post('/internal-api/banner', api_controller.addBanner);
+	router.post('/internal-api/banner/:_id', api_controller.removeBanner);
+	
 	module.exports = router;

--- a/user.js
+++ b/user.js
@@ -1,0 +1,119 @@
+const path = require('path');
+const fs = require('fs');
+const setup = require('./setup.js');
+const bans = require('./bans.js')(setup)
+const refresh = require('passport-oauth2-refresh');
+const esi = require('eve-swagger');
+const cache = require('./cache.js')(setup);
+const db = require('./dbHandler.js').db.collection('users');
+const log = require('./logger.js')(module);
+
+module.exports = function() {
+    /*
+    * @params: {user}
+    * @return: location{system_id, system_name}
+    * @todo: Use the cache for the systems 
+    */
+    module.getLocation = function (user, cb) {
+        refresh.requestNewAccessToken('provider', user.refreshToken, function (err, accessToken, newRefreshToken) {
+            if (err) {
+                log.error("user.getLocation: Error for requestNewAccessToken", { err, user });
+                cb(400, err);
+            } else {
+                module.updateRefreshToken(user.characterID, newRefreshToken);
+                esi.characters(user.characterID, accessToken).location().then(function (locationResult) {
+                    esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
+                        //cache.get(locationResult.solar_system_id, function(systemObject){
+                        var location = {
+                            id: systemObject.system_id,
+                            name: systemObject.name,
+                        }
+                        cb(location);
+                    }).catch(function(err) {
+                        log.error("user.getLocation: Error GET /universe/systems/{system_id}/", {err, user});
+                        cb({id: 0, name: "unknown", lastcheck: Date.now()});
+                    })
+                }).catch(function(err) {
+                    log.error("user.getLocation: Error GET /characters/{character_id}/location/", {err, user});
+                    cb({id: 0, name: "unknown", lastcheck: Date.now()});
+                })
+            }
+        })		
+    }
+
+    /*
+    * @params: {user}, system_id, system_name
+    * @return: cb(status)
+    */
+	module.setDestination = function(user, systemID, cb) {
+		refresh.requestNewAccessToken('provider', user.refreshToken, function (err, accessToken, newRefreshToken) {
+			if (err) {
+				log.error("user.setDestination: Error for requestNewAccessToken", { err, user });
+				cb(err);
+			} else {
+				log.debug("Setting "+user.name+"\'s destination to "+systemID);
+				esi.characters(user.characterID, accessToken).autopilot.destination(systemID).then(result => {
+					cb("OK");
+				}).catch(err => {
+					log.error("user.setDestination: ", { err });
+					cb(err);
+				});
+			}
+		})
+    }
+    
+    /*
+    * @params: {user}, target_id
+    * @return: cb(status)
+    */
+	module.showInfo = function(user, targetID, cb) {
+		refresh.requestNewAccessToken('provider', user.refreshToken, function (err, accessToken, newRefreshToken) {
+			if (err) {
+				log.error("user.showInfo: Error for requestNewAccessToken", { err, user });
+				cb(err)
+			} else {
+				log.debug("Opening "+targetID+"\'s information window for "+user.name)
+				esi.characters(user.characterID, accessToken).window.info(targetID).then(result => {
+					cb("OK");
+				}).catch(err => {
+					log.error("user.showInfo: ", { err });
+					cb(err)
+				});
+				
+			}
+		})
+	}
+
+    /*
+    * @params: {user}, target_id
+    * @return: cb(status)
+    */
+	module.openMarketWindow = function(user, targetID, cb) {
+		refresh.requestNewAccessToken('provider', user.refreshToken, function (err, accessToken, newRefreshToken) {
+			if (err) {
+				log.error("user.openMarketWindow: Error for requestNewAccessToken", { err, user });
+				cb(err)
+			} else {
+				log.debug("Opening the regional market for typeID: "+targetID+" for: "+user.name)
+				esi.characters(user.characterID, accessToken).window.market(targetID).then(result => {
+					cb("OK");
+				}).catch(err => {
+					log.error("user.openMarketWindow: ", { err });
+					cb(err)
+				});			
+			}
+		})
+	}
+
+    /*
+    * @params: userID, refreshToken
+    * @return: void
+    */
+    module.updateRefreshToken = function (userID, refreshToken) {
+		db.updateOne({ 'characterID': userID }, { $set: { refreshToken: refreshToken } }, function (err, result) {
+			if (err) log.error("updateRefreshToken: Error for updateOne", { err, 'characterID': userID });
+		})
+    }
+    
+    return module;
+}

--- a/users.js
+++ b/users.js
@@ -14,6 +14,7 @@ module.exports = function (setup) {
 	module.updateUserSession = function (req, res, next) {
 		if (typeof req.session.passport === "undefined" || typeof req.session.passport.user === "undefined") {
 			next();
+			return;
 		}
 		module.findAndReturnUser(req.session.passport.user.characterID, function (userData) {
 			if (!userData) {

--- a/views/fcFleetManage.njk
+++ b/views/fcFleetManage.njk
@@ -10,6 +10,11 @@
           <strong>This fleet is not listed:</strong> Pilots cannot see this fleet. If this is the only fleet pilots will be unable to join the waitlist!
       </div>
       {% endif %}
+      {% if fleet.fc.characterID == undefined %}
+      <div role="alert" class="alert alert-primary global-banner-inactive noselect">
+          <strong>ESI Fleet Disabled |</strong> You must set a new FC (Boss) before you can send invites.<br/>Use !esi in FC Jabber. If esi-fleets is yellow or red this issue may persist.
+      </div>
+      {% endif %}      
       <section class="no-padding-top no-padding-bottom">
         <div class="container-fluid">
           <!-- Upper Fleet Panel -->
@@ -147,10 +152,10 @@
                         </td>
                         <td>
                           <a href="javascript:void(0);" onclick="showInfo({{ user.user.characterID }})">{{ user.user.name }}</a>
-                          <p><strike>Newbee</strike></p>
+                          <p id="{{ user.user.characterID }}-status"></p>
                         </td>
                         <td>
-                          <button class="btn btn-sm btn-success" title="Invite Pilot" onclick="invitePilot('{{ user.user.characterID }}','{{ user._id }}');"><i class="fa fa-plus"></i></button>
+                          <button class="btn btn-sm btn-success {{ "" if fleet.fc.characterID else "disabled" }}" title="Invite Pilot" onclick="invitePilot('{{ user.user.characterID }}','{{ user._id }}');"><i class="fa fa-plus"></i></button>
                         </td>
                         <td>
                           <div class="dropdown">
@@ -205,10 +210,10 @@
                         </td>
                         <td>
                           <a href="javascript:void(0);" onclick="showInfo({{ user.alt.id }})">{{ user.alt.name }}</a>
-                          <p class="mb-0">Alt of: {{ user.user.name }}</p>
+                          <p id="{{ user.alt.id }}-status" class="mb-0">Alt of: {{ user.user.name }}</p>
                         </td>
                         <td>
-                          <button class="btn btn-sm btn-success" title="Invite Pilot" onclick="invitePilot('{{ user.alt.id }}','{{ user._id }}');"><i class="fa fa-plus"></i></button>
+                          <button class="btn btn-sm btn-success {{ "" if fleet.fc.characterID else "disabled" }}" title="Invite Pilot" onclick="invitePilot('{{ user.alt.id }}','{{ user._id }}');"><i class="fa fa-plus"></i></button>
                         </td>
                         <td>
                           <div class="dropdown">
@@ -282,7 +287,7 @@
     }, 15000);//Every 15 seconds
 
     //Invite a pilot to the fleet
-    function invitePilot(characterID, dbRowID, wingID, squadID) {
+    function invitePilot(characterID, dbRowID) {
         var dbRowID = dbRowID;
         var rowClass = "#row-"+dbRowID;
         var count = Number($("#fleetWaitlistCount").text());
@@ -296,7 +301,7 @@
                 $("#fleetWaitlistCount").text(count-1);
         }).fail(function(text) {
             $(rowClass).removeClass().addClass("invite-failed");
-            console.log(text.responseText);
+            $("#"+characterID+"-status").text(text.responseText);
         });
     }
 

--- a/views/partials/footer.njk
+++ b/views/partials/footer.njk
@@ -1,4 +1,64 @@
 {% block footer %}
+
+    {% if userProfile.roleNumeric > 0 %}
+    <!-- Legal Notices  Modal -->
+    <div role="dialog" tabindex="-1" class="modal fade" id="waitlistBanner">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title"><strong>Waitlist Banner Management</strong></h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                </div>
+                <div class="modal-body">
+                    <form id="test">
+                        <div class="form-group">
+                            <label>Message</label>
+                            <textarea id="bannermessage" name="text" class="form-control" max-length="200" placeholder="max 200 characters" required></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="bannertype">Banner Type</label>
+                            <select id="bannertype" name="type" class="form-control">
+                                <option value="banner-info">Information</option>
+                                <option value="banner-warning">Warning</option>
+                            </select>
+                        </div>
+                        <button id="go" class="btn btn-success btn-sm pull-right" type="submit">Set Banner</button>
+                    </form>
+                    <hr />
+                    <p class="text-center mb-0" style="font-size:x-small">Only one banner can be displayed at a time, all banners are logged.</p>
+                </div>
+            </div>
+        </div>
+        <script>
+        //Create the new banner
+        $(function() {
+            $("#go").click(function() {
+                var dataString = 'text='+ $("#bannermessage").val() + '&type=' + $("#bannertype").val();
+                 $.ajax({
+                    type: "POST",
+                    url: "/internal-api/banner",
+                    data: dataString,
+                    success: function() {
+                        location.reload();
+                    }
+                });
+            })
+        })
+
+        //Hide active banner
+        function hideBanner(_id) {
+            $.ajax({
+                type: "POST",
+                url: `/internal-api/banner/:`+_id}).done(function() {
+                    $('#topbanner').hide();
+            }).fail(function(err) {
+                console.log(err.responseText);
+            });
+        }
+        </script>
+    </div>
+    {% endif %}    
+    
     <!-- Legal Notices  Modal -->
     <div role="dialog" tabindex="-1" class="modal fade" id="legal">
         <div class="modal-dialog" role="document">

--- a/views/partials/nav.njk
+++ b/views/partials/nav.njk
@@ -70,6 +70,7 @@
                 <li><a href="/commander/tools/fits-scan">Fit Scan Tool</a></li>
                 <strike><li><a href="#">Pilot Lookup</a></strike></li>
                 <li><a href="/commander/tools/skills">Pilot Skills Lookup</a></li>
+                <li><a href="#" data-toggle="modal" data-target="#waitlistBanner">Waitlist Banner</a></li>
                 <li><a href="/commander/tools/waitlist-logs">Waitlist Log</a></li>
               </ul>                   
             {% if userProfile.roleNumeric >= 4 %}

--- a/views/waitlist.njk
+++ b/views/waitlist.njk
@@ -12,6 +12,12 @@
 					<section>
 						<!-- No Fleet -->
 						<div id="alertarea">
+							{% if banner %}
+							<div id="topbanner" role="alert" class="alert alert-primary {{ banner.class }} noselect mb-4">
+								<strong><i class="fas fa-info-circle"></i></strong> {{ banner.text }}
+								<p class="mt-0 mb-0" style="font-size:small;">Message set by: {{ banner.admin.name }}. {% if userProfile.roleNumeric > 0 %}| <a href="#" class="font-weight-bold" style="color:white!important;" onclick="hideBanner('{{banner._id}}')">admin delete</a>{% endif %}</p>
+							</div>
+							{% endif %}
 							{% if fleetCount <= 0 %}
 							<div role="alert" class="alert alert-primary global-banner-inactive noselect">
 								<strong>Waitlist Inactive:</strong> There is either no fleets, or the waitlist is not being used. Check our in-game channel for more information!

--- a/waitlistBanner.js
+++ b/waitlistBanner.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./dbHandler.js').db.collection('waitlist-banner');
+const ObjectId = require('mongodb').ObjectID;
+const setup = require('./setup.js');
+const user = require('./user.js')(setup);
+const users = require('./users.js')(setup);
+const log = require('./logger.js')(module);
+
+module.exports = function (setup) {
+    var module = {};
+
+    /*
+    * @params: {user}, message_text, message_class
+    * @return: cb(status)
+    */
+    module.createNew = function(user, message_text, message_class, cb){
+        var messagePackage = {
+            "admin": {
+                "character_id": user.character_id,
+                "name": user.name
+            },
+            "class": message_class,
+            "text": message_text,
+            "created_at": Date.now()
+        }
+        
+        db.insert(messagePackage, function (err, result) {
+            if (err) log.error("waitlistBanner.createNew: Error for db.insert", { err });
+            cb(200);
+            
+        })
+        cb(400);
+    }
+
+    /*
+    * @params: void
+    * @return: cb(banner || null)
+    */
+    module.getLast = function(cb){
+        db.find({}).sort({created_at: -1}).toArray(function (err, docs) {
+			if (err) log.error("waitlistBanner.getLast: Error for db.find", { err });
+            if(docs.length > 0 && docs[0].deleted == true){
+                cb(null)
+            } else {
+                cb(docs[0])
+            }
+		})
+    }
+
+    /*
+    * @params: _id
+    * @return: cb(status)
+    */
+    module.hideLast = function(cb){
+        db.updateMany({}, { $set: { deleted: true} }, function (err, result) {
+            if (err) log.error("waitlistBanner.hideLast: Error for db.update", { err });
+        })
+        
+        cb(200);
+    }
+    return module;
+}


### PR DESCRIPTION
## Waitlist Banners
- FCs can now set one banner for the public waitlist page. 
- This banner will either be blue or red
- Creating a new banner will replace the old one
- Any FC can set or remove a banner

## No ESI Waitlist
Increased the fleet error threshold to 10. If this threshold is reached the FC object is removed and the fleet remains open _(The fleet used to be closed by the waitlist)_. While there is no FC assigned to a fleet the following features will not work:
- Fleet at a Glance: This will continue to show the last fleet comp scraped by ESI
- Fleet Location: This will continue to show the last known location of the FC before they were removed
- Fleet Invites: FCs can click on a pilot name opening their info window in game. The FC can then drag their picture into the fleet comp inviting them. The standard alarm and remove buttons still work.

__OTHER__
- A banner will show at the top to indicate that ESI fleet mode is disabled.
- Failed invites will now show a reason on their waitlist strip.

## Created a new file ```user.js```. 

`User.js` should hold functions that are for a single user at a time where `users.js` should be for functions that affect multiple users or the users table as a whole.

**Functions moved to `user.js`:**

- `ESI /location/`
- `ESI /ui/info/`
- `ESI /ui/waypoint/`
- `ESI /ui/market`
- Save updated refresh target

I've also deleted the deleteUser function from users.js because this shouldn't exist. Deleting data is bad.