### PR TITLE
Fixing Cache Mega Null Array

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -10,7 +10,7 @@ module.exports = function (setup) {
 
 	module.query = function (id, cb) {
 		if (typeof id === "number" || typeof id === "string") {
-			id = new Array(id);
+			id = Array.of(id);
 		}
 		esi.names(id).then(function (item) {
 			cb(item[0]);

--- a/user.js
+++ b/user.js
@@ -22,8 +22,8 @@ module.exports = function() {
             } else {
                 module.updateRefreshToken(user.characterID, newRefreshToken);
                 esi.characters(user.characterID, accessToken).location().then(function (locationResult) {
-                    esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
-                        //cache.get(locationResult.solar_system_id, function(systemObject){
+                    // esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
+                    cache.get(locationResult.solar_system_id, function(systemObject){
                         var location = {
                             id: systemObject.system_id,
                             name: systemObject.name,


### PR DESCRIPTION
Changed `new Array(N)` to `Array.of(N)`. `new Array(N)` will make an array of length N filled with undefined values.

This probably changed between a node version which could have caused the repro case to not be 100%