### PR TITLE
Cache Expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# For any scratch files to run little tests
+scratch/

--- a/cache.js
+++ b/cache.js
@@ -53,9 +53,11 @@ module.exports = function (setup) {
 				fetch(id, expiresIn, cb);
 			} else {
 				// Check to see if document has expired
-				if(!!doc.expires && doc.expires < epoch()) {
+				if(!!doc.expires && !!expiresIn && doc.expires < epoch()) {
 					fetch(id, expiresIn, cb);
 				} else {
+					// if we didn't need to expire or didn't expire, lets just 
+					// return the doc as is
 					cb(doc)
 					module.removeFromCacheTemp(id);
 				}

--- a/cache.js
+++ b/cache.js
@@ -10,7 +10,7 @@ module.exports = function (setup) {
 
 	module.query = function (id, cb) {
 		if (typeof id === "number" || typeof id === "string") {
-			id = new Array(id);
+			id = Array.of(id);
 		}
 		esi.names(id).then(function (item) {
 			cb(item[0]);

--- a/controllers/apiController.js
+++ b/controllers/apiController.js
@@ -49,7 +49,7 @@ exports.fleetAtAGlance = function(req, res) {
             
             var counter = 0;
             for(var i = 0; i < fleet.members.length; i++) { //where the fuck is shipID coming from? I'm bad
-                cache.get(fleet.members[i].ship_type_id, function(ship) {
+                cache.get(fleet.members[i].ship_type_id, null, function(ship) {
                 ships.push(ship); //<<<<<
                 counter++;
                     if(counter === fleet.members.length) {

--- a/user.js
+++ b/user.js
@@ -22,8 +22,8 @@ module.exports = function() {
             } else {
                 module.updateRefreshToken(user.characterID, newRefreshToken);
                 esi.characters(user.characterID, accessToken).location().then(function (locationResult) {
-                    esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
-                        //cache.get(locationResult.solar_system_id, function(systemObject){
+                    // esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
+                    cache.get(locationResult.solar_system_id, function(systemObject){
                         var location = {
                             id: systemObject.system_id,
                             name: systemObject.name,

--- a/user.js
+++ b/user.js
@@ -23,7 +23,7 @@ module.exports = function() {
                 module.updateRefreshToken(user.characterID, newRefreshToken);
                 esi.characters(user.characterID, accessToken).location().then(function (locationResult) {
                     // esi.solarSystems(locationResult.solar_system_id).info().then(function(systemObject) { 
-                    cache.get(locationResult.solar_system_id, function(systemObject){
+                    cache.get(locationResult.solar_system_id, null, function(systemObject){
                         var location = {
                             id: systemObject.system_id,
                             name: systemObject.name,


### PR DESCRIPTION
Added a new argument to cache.get allowing the caller to specify a expiration in seconds from now. This is not an optional field however. If you don't want an expiration, pass in null.

I have pulled in the fixes from #112 so there aren't any issues merging this in.